### PR TITLE
feat: add IP whitelist

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,7 @@ module.exports = withBundleAnalyzer(
 			NEXT_PUBLIC_BUILD_TIMESTAMP: +date,
 			NEXT_PUBLIC_APP_NAME: packageJson.name,
 			NEXT_PUBLIC_APP_VERSION: packageJson.version,
+			CF_IP: process.env.CF_IP,
 		},
 		experimental: {
 			redirects() {

--- a/next.config.js
+++ b/next.config.js
@@ -3,8 +3,9 @@ const nextSourceMaps = require('@zeit/next-source-maps');
 const packageJson = require('./package');
 
 const withSourceMaps = nextSourceMaps();
-const withBundleAnalyzer = bundleAnalyzer({ // Run with "yarn analyse:bundle" - See https://www.npmjs.com/package/@next/bundle-analyzer
-  enabled: process.env.ANALYZE_BUNDLE === 'true',
+const withBundleAnalyzer = bundleAnalyzer({
+	// Run with "yarn analyse:bundle" - See https://www.npmjs.com/package/@next/bundle-analyzer
+	enabled: process.env.ANALYZE_BUNDLE === 'true',
 });
 
 const noRedirectBlacklistedPaths = ['_next', 'api']; // Paths that mustn't have rewrite applied to them, to avoid the whole app to behave inconsistently
@@ -12,70 +13,82 @@ const publicBasePaths = ['robots', 'static', 'favicon.ico']; // All items (folde
 const noRedirectBasePaths = [...publicBasePaths, ...noRedirectBlacklistedPaths]; // Will disable url rewrite for those items (should contain all supported languages and all public base paths)
 const date = new Date();
 
-console.debug(`Building Next with NODE_ENV="${process.env.NODE_ENV}" NEXT_PUBLIC_APP_STAGE="${process.env.NEXT_PUBLIC_APP_STAGE}"`);
+console.debug(
+	`Building Next with NODE_ENV="${process.env.NODE_ENV}" NEXT_PUBLIC_APP_STAGE="${process.env.NEXT_PUBLIC_APP_STAGE}"`
+);
 
-module.exports = withBundleAnalyzer(withSourceMaps({
-  // target: 'serverless', // Automatically enabled on Vercel, you may need to manually opt-in if you're not using Vercel - See https://nextjs.org/docs/api-reference/next.config.js/build-target#serverless-target
-  env: {
-    // XXX All env variables defined in ".env*" files that aren't public (don't start with "NEXT_PUBLIC_") MUST manually be made available at build time below
-    //  They're necessary on Vercel for runtime execution (SSR, SSG with revalidate, everything that happens server-side will need those)
-    //  See https://nextjs.org/docs/api-reference/next.config.js/environment-variables
+module.exports = withBundleAnalyzer(
+	withSourceMaps({
+		// target: 'serverless', // Automatically enabled on Vercel, you may need to manually opt-in if you're not using Vercel - See https://nextjs.org/docs/api-reference/next.config.js/build-target#serverless-target
+		env: {
+			// XXX All env variables defined in ".env*" files that aren't public (don't start with "NEXT_PUBLIC_") MUST manually be made available at build time below
+			//  They're necessary on Vercel for runtime execution (SSR, SSG with revalidate, everything that happens server-side will need those)
+			//  See https://nextjs.org/docs/api-reference/next.config.js/environment-variables
 
-    // Dynamic env variables
-    NEXT_PUBLIC_BUILD_TIME: date.toString(),
-    NEXT_PUBLIC_BUILD_TIMESTAMP: +date,
-    NEXT_PUBLIC_APP_NAME: packageJson.name,
-    NEXT_PUBLIC_APP_VERSION: packageJson.version,
-  },
-  experimental: {
-    redirects() {
-      // const redirects = [
-      //   {
-      //     // Redirect root link with trailing slash to non-trailing slash, avoids 404 - See https://github.com/vercel/next.js/discussions/10651#discussioncomment-8270
-      //     source: '/:locale/',
-      //     destination: '/:locale',
-      //     permanent: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Do not use permanent redirect locally to avoid browser caching when working on it
-      //   },
-      //   {
-      //     // Redirect link with trailing slash to non-trailing slash (any depth), avoids 404 - See https://github.com/vercel/next.js/discussions/10651#discussioncomment-8270
-      //     source: '/:locale/:path*/',
-      //     destination: '/:locale/:path*',
-      //     permanent: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Do not use permanent redirect locally to avoid browser caching when working on it
-      //   },
-      // ];
+			// Dynamic env variables
+			NEXT_PUBLIC_BUILD_TIME: date.toString(),
+			NEXT_PUBLIC_BUILD_TIMESTAMP: +date,
+			NEXT_PUBLIC_APP_NAME: packageJson.name,
+			NEXT_PUBLIC_APP_VERSION: packageJson.version,
+		},
+		experimental: {
+			redirects() {
+				// const redirects = [
+				//   {
+				//     // Redirect root link with trailing slash to non-trailing slash, avoids 404 - See https://github.com/vercel/next.js/discussions/10651#discussioncomment-8270
+				//     source: '/:locale/',
+				//     destination: '/:locale',
+				//     permanent: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Do not use permanent redirect locally to avoid browser caching when working on it
+				//   },
+				//   {
+				//     // Redirect link with trailing slash to non-trailing slash (any depth), avoids 404 - See https://github.com/vercel/next.js/discussions/10651#discussioncomment-8270
+				//     source: '/:locale/:path*/',
+				//     destination: '/:locale/:path*',
+				//     permanent: process.env.NEXT_PUBLIC_APP_STAGE !== 'development', // Do not use permanent redirect locally to avoid browser caching when working on it
+				//   },
+				// ];
 
-      // if (process.env.NEXT_PUBLIC_APP_STAGE === 'development') {
-      //   console.info('Using experimental redirects:', redirects);
-      // }
+				// if (process.env.NEXT_PUBLIC_APP_STAGE === 'development') {
+				//   console.info('Using experimental redirects:', redirects);
+				// }
 
-      return redirects;
-    },
-  },
-  webpack: (config, { isServer, buildId }) => {
-    if (isServer) {
-      // IS_SERVER_INITIAL_BUILD is meant to be defined only at build time and not at run time, and therefore must not be "made public"
-      process.env.IS_SERVER_INITIAL_BUILD = '1';
-    }
+				return redirects;
+			},
+		},
+		webpack: (config, { isServer, buildId }) => {
+			if (isServer) {
+				// IS_SERVER_INITIAL_BUILD is meant to be defined only at build time and not at run time, and therefore must not be "made public"
+				process.env.IS_SERVER_INITIAL_BUILD = '1';
+			}
 
-    const APP_VERSION_RELEASE = `${packageJson.version}_${buildId}`;
-    config.plugins.map((plugin, i) => {
-      if (plugin.definitions) { // If it has a "definitions" key, then we consider it's the DefinePlugin where ENV vars are stored
-        // Dynamically add some "public env" variables that will be replaced during the build through "DefinePlugin"
-        // Those variables are considered public because they are available at build time and at run time (they'll be replaced during initial build, by their value)
-        plugin.definitions['process.env.NEXT_PUBLIC_APP_BUILD_ID'] = JSON.stringify(buildId);
-        plugin.definitions['process.env.NEXT_PUBLIC_APP_VERSION_RELEASE'] = JSON.stringify(APP_VERSION_RELEASE);
-      }
-    });
+			const APP_VERSION_RELEASE = `${packageJson.version}_${buildId}`;
+			config.plugins.map((plugin, i) => {
+				if (plugin.definitions) {
+					// If it has a "definitions" key, then we consider it's the DefinePlugin where ENV vars are stored
+					// Dynamically add some "public env" variables that will be replaced during the build through "DefinePlugin"
+					// Those variables are considered public because they are available at build time and at run time (they'll be replaced during initial build, by their value)
+					plugin.definitions['process.env.NEXT_PUBLIC_APP_BUILD_ID'] = JSON.stringify(buildId);
+					plugin.definitions['process.env.NEXT_PUBLIC_APP_VERSION_RELEASE'] = JSON.stringify(
+						APP_VERSION_RELEASE
+					);
+				}
+			});
 
-    if (isServer) { // Trick to only log once
-      console.debug(`[webpack] Building release "${APP_VERSION_RELEASE}" using NODE_ENV="${process.env.NODE_ENV}" ${process.env.IS_SERVER_INITIAL_BUILD ? 'with IS_SERVER_INITIAL_BUILD="1"': ''}`);
-    }
+			if (isServer) {
+				// Trick to only log once
+				console.debug(
+					`[webpack] Building release "${APP_VERSION_RELEASE}" using NODE_ENV="${
+						process.env.NODE_ENV
+					}" ${process.env.IS_SERVER_INITIAL_BUILD ? 'with IS_SERVER_INITIAL_BUILD="1"' : ''}`
+				);
+			}
 
-    // Fixes npm packages that depend on `fs` module
-    config.node = {
-      fs: 'empty',
-    };
+			// Fixes npm packages that depend on `fs` module
+			config.node = {
+				fs: 'empty',
+			};
 
-    return config;
-  },
-}));
+			return config;
+		},
+	})
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6985,11 +6985,18 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ip-range-check": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+      "integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+      "requires": {
+        "ipaddr.js": "^1.0.1"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@types/react-slick": "^0.23.4",
 		"@types/react-transition-group": "^4.4.0",
 		"axios": "0.20.0",
+		"ip-range-check": "0.2.0",
 		"next": "9.5.5",
 		"numeral": "2.0.6",
 		"react": "16.13.1",

--- a/process.env.d.ts
+++ b/process.env.d.ts
@@ -20,6 +20,7 @@ declare global {
 			NEXT_PUBLIC_APP_STAGE: 'test' | 'development' | 'staging' | 'production';
 			NEXT_PUBLIC_BUILD_TIME: string;
 			NEXT_PUBLIC_BUILD_TIMESTAMP: string;
+			CF_IP: string | undefined;
 		}
 	}
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,14 @@
 import Head from 'next/head';
 import { GetServerSideProps } from 'next';
+import dynamic from 'next/dynamic';
+
+import ipRangeCheck from 'ip-range-check';
 
 import MainSection from '../sections/home/main';
 import BuildSection from '../sections/home/build';
 import TotalSection from '../sections/home/total';
 import EarnSection from '../sections/home/earn';
 import PartnersSection from '../sections/home/partners';
-import dynamic from 'next/dynamic';
 import { Layout } from '../components';
 import { fetchTotalLocked } from '../../lib/exchange-api';
 
@@ -45,13 +47,29 @@ const Home = ({ totalLocked }: ApiStatsProps) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-	const totalLocked = await fetchTotalLocked();
-
-	return {
-		props: {
-			totalLocked,
-		},
-	};
+	if (process.env.CF_IP) {
+		const allowedIps = JSON.parse(`[${process.env.CF_IP}]`);
+		const ip = context.req.headers['x-forwarded-for'] || context.req.connection.remoteAddress;
+		if (typeof ip === 'string' && ipRangeCheck(ip, allowedIps)) {
+			const props = await getProps();
+			return props;
+		} else {
+			context.res.statusCode = 403;
+			context.res.end('Your IP is not whitelisted.');
+			return {};
+		}
+	} else {
+		const props = await getProps();
+		return props;
+	}
+	async function getProps() {
+		const totalLocked = await fetchTotalLocked();
+		return {
+			props: {
+				totalLocked,
+			},
+		};
+	}
 };
 
 export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,7 +49,7 @@ const Home = ({ totalLocked }: ApiStatsProps) => {
 export const getServerSideProps: GetServerSideProps = async (context) => {
 	if (process.env.CF_IP) {
 		const allowedIps = JSON.parse(`[${process.env.CF_IP}]`);
-		const ip = context.req.headers['x-forwarded-for'] || context.req.connection.remoteAddress;
+		const ip = context.req.connection.remoteAddress;
 		if (typeof ip === 'string' && ipRangeCheck(ip, allowedIps)) {
 			const props = await getProps();
 			return props;


### PR DESCRIPTION
This feature adds IP whitelisting when `CF_IP` environmental variable is present (which will be present only on production builds).
Its intention is to allow requests only from AWS CloudFront instances and to disallow users to skip it.