### PR TITLE
add robots.txt and sitemap.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+Sitemap: https://synthetix.io/sitemap.xml
+
+User-agent: *
+Allow: /*
+
+Disallow: /_next/static/

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://synthetix.io/</loc>
+    <lastmod>2020-11-11</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Adds robot.txt and sitemap.xml.

It won't work on feature branch deployments (so they won't be indexed) because they have `X-Robots-Tag: noindex` header present by default which disables indexing.