### PR TITLE
feat: add sitemap.xml/robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# sitemap
+/public/robots.txt
+/public/sitemap.xml

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,0 +1,15 @@
+module.exports = {
+	siteUrl: 'https://synthetix.io',
+	changefreq: 'daily',
+	priority: 0.9,
+	generateRobotsTxt: true,
+	robotsTxtOptions: {
+		policies: [
+			{
+				userAgent: '*',
+				allow: '/',
+				disallow: ['/_next/static/'],
+			},
+		],
+	},
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1607,6 +1607,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@corex/deepmerge": {
+      "version": "2.4.24",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-2.4.24.tgz",
+      "integrity": "sha512-TBYXnhxYU9kqDhUXm/rgDRRAxHVpX8Y3ZX+zmTmQuhRF9p7orsrx+P/lVXS7PcPnOFFVE3ZvyE5MIYFipecy8g==",
+      "dev": true
+    },
     "@cypress/listr-verbose-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
@@ -8412,6 +8418,16 @@
             "to-fast-properties": "^2.0.0"
           }
         }
+      }
+    },
+    "next-sitemap": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-1.3.2.tgz",
+      "integrity": "sha512-wOVIRxVaSAtcr35K0Mi6rtfTwY0nw2UWpcbAUORscGIeU/O/V22Qq1dkodf1h2ftc/MMTrDYYkiMBhkiWh0O/w==",
+      "dev": true,
+      "requires": {
+        "@corex/deepmerge": "^2.4.24",
+        "minimist": "^1.2.5"
       }
     },
     "next-tick": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"eslint-plugin-prettier": "3.1.4",
 		"eslint-plugin-react": "7.20.6",
 		"eslint-plugin-react-hooks": "2.5.1",
+		"next-sitemap": "1.3.2",
 		"ngrok": "^3.2.7",
 		"now": "19.1.0",
 		"prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",
+		"postbuild": "if [[ ${BUILD_SITEMAP} ]]; then next-sitemap --config next-sitemap.js; fi",
 		"start": "next start --port 8888",
 		"start:tunnel": "ngrok http 8888",
 		"svg": "npx svgr -d src/svg src/svg --ext tsx --template src/utils/svgTemplate.ts",


### PR DESCRIPTION
Automatically generates `sitemap.xml` / `robots.txt` based on pages found in `src/pages` folder making our website more SEO-friendly (resulting in better positioning in google search).
They are generated only if `BUILD_SITEMAP` environmental variable is present (which is present only on production builds to avoid having it on staging/feature branch deployments).