### PR TITLE
specify matrix well-known configuration

### DIFF
--- a/public/.well-known/matrix/client
+++ b/public/.well-known/matrix/client
@@ -1,0 +1,5 @@
+{
+  "m.homeserver": {
+    "base_url": "https://matrix.synthetix.io"
+  }
+}


### PR DESCRIPTION
in experimentation with [matrix](https://matrix.org/) as a future chatting option for the community, we need to specify a well-known directory configuration on our main domain in order to ensure linkage between our server and other matrix servers.