### PR TITLE
chore: update kwenta domain

### DIFF
--- a/pages/linn-sandstrom.tsx
+++ b/pages/linn-sandstrom.tsx
@@ -77,7 +77,7 @@ function LinnSandstrom() {
 								isExternalLink
 								icon={<ArrowLinkOffIcon active />}
 								text="Trade"
-								link="https://kwenta.io/"
+								link="https://kwenta.eth.limo/"
 							></StyledLinkButton>
 						</StyledCardContent>
 					</StyledCard>

--- a/src/sections/home/poweredBy.tsx
+++ b/src/sections/home/poweredBy.tsx
@@ -22,7 +22,7 @@ const poweredByCards: PoweredByCards[] = [
 		name: 'Kwenta',
 		description:
 			'Trade with up to 10x leverage and simulated liquidity for the best price fills. Coming soon.',
-		link: 'https://kwenta.io',
+		link: 'https://kwenta.eth.limo',
 		logo: '/kwenta.png',
 	},
 	{

--- a/src/sections/home/synths.tsx
+++ b/src/sections/home/synths.tsx
@@ -192,7 +192,7 @@ const accordionItems: AccordionItemsType[] = [
 			<BuildButton
 				size="medium"
 				buttonType="primary"
-				link="https://kwenta.io/"
+				link="https://kwenta.eth.limo/"
 				external={true}
 				key="trade-synth-button"
 				margin="19px 0px 0px"

--- a/src/sections/perps/frontends.tsx
+++ b/src/sections/perps/frontends.tsx
@@ -83,7 +83,7 @@ const FrontEnds = ({ ...props }: FlexProps) => {
 							a single cross-margin contract.
 						</Text>
 						<Link
-							href="https://kwenta.io/"
+							href="https://kwenta.eth.limo/"
 							target="_blank"
 							alignSelf="flex-end"
 							display="flex"

--- a/src/sections/perps/main.tsx
+++ b/src/sections/perps/main.tsx
@@ -46,7 +46,7 @@ export default function FuturesMain({ ...props }: FlexProps) {
 				</Text>
 				<Flex mt={8}>
 					<Link
-						href="https://kwenta.io"
+						href="https://kwenta.eth.limo"
 						borderRadius="4px"
 						bg="cyan.500"
 						boxShadow="0px 0px 10px rgba(0, 209, 255, 0.9)"

--- a/src/sections/synths/SynthCard.tsx
+++ b/src/sections/synths/SynthCard.tsx
@@ -40,8 +40,8 @@ const SynthCard: FC<SynthCardProps> = ({ synth, price, exchangeFeeRate, status }
 		<ExternalLink
 			href={
 				currencyKey !== 'sUSD'
-					? `https://kwenta.io/exchange/?quote=${currencyKey}&base=sUSD`
-					: `https://kwenta.io/exchange/?quote=${currencyKey}&base=sETH`
+					? `https://kwenta.eth.limo/exchange/?quote=${currencyKey}&base=sUSD`
+					: `https://kwenta.eth.limo/exchange/?quote=${currencyKey}&base=sETH`
 			}
 		>
 			<StyledCard>


### PR DESCRIPTION
* Update all links of `kwenta.io` to the actual Kwenta endorsed domain `kwenta.eth.limo`.

### Rationale
`kwenta.io` has been deprecated months ago, and while currently redirecting to `kwenta.eth.limo`, the domain might be fully disabled or used for other purposes in the future.